### PR TITLE
add automation and hierarchy example

### DIFF
--- a/policies/default-policy.json
+++ b/policies/default-policy.json
@@ -1,0 +1,11 @@
+{
+    "dbus_per_hour" : {
+      "type" : "range",
+      "maxValue" : 10
+    },
+    "autotermination_minutes" : {
+      "type" : "fixed",
+      "value" : 20,
+      "hidden" : true
+    }
+  }

--- a/terraform/examples/main.tf
+++ b/terraform/examples/main.tf
@@ -1,0 +1,23 @@
+module "marketing_compute_policy" {
+  source = "../modules/base-cluster-policy"
+  team   = "marketing"
+  policy_overrides = {
+    // only marketing guys will benefit from delta cache this way
+    "spark_conf.spark.databricks.io.cache.enabled" : {
+      "type" : "fixed",
+      "value" : "true"
+    },
+  }
+}
+
+module "engineering_compute_policy" {
+  source = "../modules/base-cluster-policy"
+  team   = "engineering"
+  policy_overrides = {
+    "dbus_per_hour" : {
+      "type" : "range",
+      // allow data engineering to use larger clusters
+      "maxValue" : 50
+    },
+  }
+}

--- a/terraform/modules/base-cluster-policy/main.tf
+++ b/terraform/modules/base-cluster-policy/main.tf
@@ -1,0 +1,20 @@
+variable "team" {
+  description = "line of business that owns the workloads"
+}
+
+variable "policy_overrides" {
+  description = "Cluster policy overrides"
+}
+
+resource "databricks_cluster_policy" "fair_use" {
+  name       = "${var.team} cluster policy"
+  definition = jsonencode(merge(jsondecode(file("../../../policies/default-policy.json")), var.policy_overrides))
+}
+
+resource "databricks_permissions" "can_use_cluster_policyinstance_profile" {
+  cluster_policy_id = databricks_cluster_policy.fair_use.id
+  access_control {
+    group_name       = var.team
+    permission_level = "CAN_USE"
+  }
+}


### PR DESCRIPTION
What's included: 

- Terraform folder to show examples for automating installation of policies
- Example of using base policy and referencing this from the main `policies` folder
- Example of using inheritance for cluster policies for simpler management and templating